### PR TITLE
Removed Microsoft CMT link (from Authors Page)

### DIFF
--- a/src/Pages/CallForPaper.jsx
+++ b/src/Pages/CallForPaper.jsx
@@ -32,7 +32,7 @@ const CallForPaper = () => {
         <p>
 
          <strong> Authors, </strong>
-         are invited to submit their full manuscripts (6 pages max) according to guidelines available on the conference website via Microsoft CMT: <a href='https://cmt3.research.microsoft.com/NEIECCE2025'>https://cmt3.research.microsoft.com/NEIECCE2025</a>. </p>
+         are invited to submit their full manuscripts (6 pages max) according to guidelines available on the conference website via Microsoft CMT. </p>
 
           
              <br />


### PR DESCRIPTION
As requested from higher authority, the Microsoft CMT link (from Authors Page) has been removed.